### PR TITLE
add initial docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 Cargill, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# code-of-conduct
-Code of conduct for contributing to Cargill OSS
+# Cargill Code of Conduct
+
+
+## Types of Contributions
+
+There are many types of contributions. At Cargill, we are encourage engagement in the community through Issues. Some examples of contributions we welcome:
+
+- Documentation
+- Translation
+- Bug/fix (Issues)
+- New features (Backlog)
+- Testing
+
+## Code of Conduct
+
+Please see our [code of conduct](code-of-conduct.md)
+
+## Style Guides
+
+With different repos having different languages, scopes, and purposes, the individual repos will have their own respective style guides. Please see style guides within the project repos.
+
+## Submitting PRs
+
+Please look at the project repos `First Good Issue` for examples of initiating a topic. Use a `fork-branch-pr` approach to submitting Pull Requests (PRs).
+
+PRs should address:
+
+- What problem is being addressed
+- What changes are being introduced
+- Reference to any other Issues
+- Updated tests (if applicable)
+- Updated docs (if applicable)
+
+## Contacts
+
+[WIP]
+
+- Maintainer's Github names
+- Chat channel links
+- Escalation contact/flow (I found a vulnerability!)
+
+## Community Connections
+
+[WIP]
+
+- Mailing lists
+- Meeting groups (meetups)

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,78 @@
+# Contributor Covenant Code of Conduct
+
+View [README](README.md)
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq


### PR DESCRIPTION
Signed-off-by: Jason <j_walker@cargill.com>

@davececchi - 

An initial take on Code of Conduct and other items for OSS. This would be the basic place for us to have an umbrella set of policies (light weight) with tons of flexibility to defer specifics to repos/projects. For example, `pipewrench` and `splinter` not having the same style guides makes sense. But both having a code of conduct that includes verbiage around not being a jerk feels right.

Thoughts?