### PR TITLE
add email address to content

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ PRs should address:
 
 ## Contacts
 
+Please reach out to <opensource@cargill.com> with questions related to any of our contributions or projects.
+
 [WIP]
 
 - Maintainer's Github names

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -57,7 +57,7 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at <opensource@cargill.com>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Signed-off-by: Jason <j_walker@cargill.com>

# `changes`

- add email to README
- add email to `code of conduct`